### PR TITLE
Shrink `Jim_Scope` size from 12 to 1 byte

### DIFF
--- a/jim.h
+++ b/jim.h
@@ -25,9 +25,9 @@ typedef enum {
 } Jim_Scope_Kind;
 
 typedef struct {
-    Jim_Scope_Kind kind;
-    int tail;
-    int key;
+    unsigned char kind : 6;
+    unsigned char tail : 1;
+    unsigned char key : 1;
 } Jim_Scope;
 
 typedef struct {

--- a/test.c
+++ b/test.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <assert.h>
 
 #define JIM_IMPLEMENTATION
 #include "./jim.h"
@@ -202,6 +203,8 @@ void test(void)
 
 int main(int argc, char **argv)
 {
+    assert(sizeof(Jim_Scope) == 1);
+
     if (argc >= 2) {
         if (strcmp(argv[1], "record") == 0) {
             record("test_expected.h");


### PR DESCRIPTION
Hi @rexim :wave:

I came across this library while I was watching your youtube video on implementing GC in C (awesome video btw). And thought I'd check it out :)

While checking the code I found that we keep the scopes as three `int`s one for kind, one for tail and one for key. The size of this is 12 bytes. But we can store it as bit field. And keep 6 bits for the kind (enough to store 64 different kinds, we only have 2 now), 1 bit for the tail and another 1 bit for key (since key and tail can only be 1 or 0 we only need 1 bit). With this we save 11 bytes per scope. And since we have 128 by default, that's 1408 less bytes for the `Jim` struct.
